### PR TITLE
For iOS 10, add a NSCameraUsageDescription and NSPhotoLibraryUsageDescription. 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -98,6 +98,16 @@
          <framework src="CoreGraphics.framework" />
          <framework src="AssetsLibrary.framework" />
          <framework src="MobileCoreServices.framework" />
+
+         <preference name="CAMERA_USAGE_DESCRIPTION" default=" " />
+         <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
+             <string>$CAMERA_USAGE_DESCRIPTION</string>
+         </config-file>
+
+         <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default=" " />
+         <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+             <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
+         </config-file>
      </platform>
 
      <!-- windows8 -->


### PR DESCRIPTION
 Since iOS 10 it's mandatory to add a NSCameraUsageDescription and NSPhotoLibraryUsageDescription in the info.plist.
    
    NSCameraUsageDescription describes the reason that the app accesses the
    user’s camera.
    NSPhotoLibraryUsageDescription describes the reason the app accesses the
    user's photo library.
